### PR TITLE
Specify `include_data=false` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ v = dataset("cars") |> Voyager()
 
 # Now create the plot in the UI
 
-v[] |> save("figure1.vegalite")
+v[] |> save("figure1.vegalite"; include_data=false)
 ````
 
 At a later point you can then load this figure specification again, but pipe new data into it:


### PR DESCRIPTION
As of https://github.com/fredo-dedup/VegaLite.jl/pull/99, `include_data` for `FileIO.save` defaults to `true`. README.md is updated to reflect this change.
