### PR TITLE
Properly encoding spaces in directory paths.

### DIFF
--- a/src/DataVoyager.jl
+++ b/src/DataVoyager.jl
@@ -12,7 +12,7 @@ mutable struct Voyager
     w::Window
 
     function Voyager()
-        main_html_uri = string("file:///", replace(joinpath(@__DIR__, "htmlui", "main.html"), '\\' => '/'))
+        main_html_uri = string("file:///", replace(replace(joinpath(@__DIR__, "htmlui", "main.html"), '\\' => '/'), " " => "%20"))
 
         global app
 


### PR DESCRIPTION
Updating DataVoyager.jl to properly encode for spaces in directory paths. Before spaces would throw off the URI encoder and give an "unexpected character in path" error. This replaces spaces with proper web encoding. Tested locally.