### PR TITLE
Close the Electron windows the tests open

### DIFF
--- a/src/DataVoyager.jl
+++ b/src/DataVoyager.jl
@@ -16,7 +16,7 @@ mutable struct Voyager
 
         global app
 
-        if app === nothing
+        if app === nothing || !app.exists
             app = Application()
         end
 

--- a/test/test_datavoyager.jl
+++ b/test/test_datavoyager.jl
@@ -4,27 +4,41 @@
 
     Electron.prep_test_env()
 
-    source = [(a = 1, b = 1), (a = 2, b = 2)]
-    source2 = [(a = DataValue(1), b = DataValue{Int}()), (a = DataValue{Int}(), b = DataValue(2))]
+    try
+        source = [(a = 1, b = 1), (a = 2, b = 2)]
+        source2 = [(a = DataValue(1), b = DataValue{Int}()), (a = DataValue{Int}(), b = DataValue(2))]
 
-    v = Voyager()
-    @test typeof(v.w) == Electron.Window
+        v = Voyager()
+        @test typeof(v.w) == Electron.Window
 
-    v = Voyager(source)
-    @test typeof(v.w) == Electron.Window
+        v = Voyager(source)
+        @test typeof(v.w) == Electron.Window
 
-    v(source)
-    @test typeof(v.w) == Electron.Window
+        v(source)
+        @test typeof(v.w) == Electron.Window
 
-    source |> v
-    @test typeof(v.w) == Electron.Window
+        source |> v
+        @test typeof(v.w) == Electron.Window
 
-    v = Voyager(source2)
-    @test typeof(v.w) == Electron.Window
+        v = Voyager(source2)
+        @test typeof(v.w) == Electron.Window
 
-    v(source2)
-    @test typeof(v.w) == Electron.Window
+        v(source2)
+        @test typeof(v.w) == Electron.Window
 
-    source2 |> v
-    @test typeof(v.w) == Electron.Window
+        source2 |> v
+        @test typeof(v.w) == Electron.Window
+    finally
+        # Close every window opened during the test. Each window is closed at most
+        # once, from a snapshot of the window list: `close(app)` instead loops over
+        # `windows(app)`, and re-closes a window whose asynchronous "windowclosed"
+        # notification has not arrived yet -- Electron never replies to a close for a
+        # window it already destroyed, so that call blocks forever.
+        for app in Electron.applications()
+            app.exists || continue
+            for win in copy(Electron.windows(app))
+                win.exists && close(win)
+            end
+        end
+    end
 end


### PR DESCRIPTION
The test item creates three `Voyager` instances — three Electron windows — and closes none of them. They are left on screen after a test run, and the Electron process survives until Julia's `atexit` hook eventually runs.

The body is now wrapped in `try`/`finally`, and the `finally` closes every window that is still open, so a failure part way through cleans up too.

Each window is closed at most once, from a snapshot of the window list, rather than through `Electron.close(app)`. That function loops `while length(windows(app)) > 0; close(first(windows(app))); end`, and removal from `app.windows` only happens when the asynchronous `windowclosed` notification arrives — so it can re-close a window that is already destroyed. Electron's `main.js` does `BrowserWindow.fromId(...).destroy()` and only then writes its reply, so for an already destroyed window it throws and never replies, and Julia blocks forever. The same teardown is used in ElectronDisplay.jl (queryverse/ElectronDisplay.jl#102), where `close(app)` reliably hung the test item.

Also: `DataVoyager.app` was set once and never re-checked, so once the application it pointed at had gone away — a user closing the Voyager window's app, say — every later `Voyager()` failed on the dead handle. It is now recreated when `!app.exists`.

### Verification

The test item passes locally on Julia 1.12 with no window left behind (checked with `Get-Process electron`), and re-running it in a warm worker reuses the application correctly. The `Voyager()`-after-`close(app)` path was exercised directly in a session: it now creates a fresh application instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)